### PR TITLE
docs: 新增发送队列与多选分享功能说明文档

### DIFF
--- a/docs/01_发送队列.md
+++ b/docs/01_发送队列.md
@@ -1,0 +1,275 @@
+# 一、发送队列（Send Queue）
+
+## 设计思想
+
+传统聊天 APP 在 AI 输出时会**锁定输入框**，用户必须等 AI 说完才能发下一条。这种体验在长回复场景下极其糟糕。
+
+我们的设计目标：**AI 输出时用户随时可以打字、随时可以发送，支持多条叠加排队，不打断、不阻塞。**
+
+核心理念：
+- 输入框**永不禁用**，用户任何时候都能编辑
+- 发送时 AI 正在输出 → 消息进入队列等待，可连续追加多条
+- 提供**可视化反馈**（橙色等待块，显示排队条数）+ **一键清空**
+- **输入框有内容时按发送 = 追加排队**（不打断 AI）
+- **输入框为空时按发送 = 停止 AI**，AI 停止后自动发送队列第一条
+- AI 自然输出完成 → 自动发送队列第一条 → AI 再响应 → 再发下一条...
+
+## 交互流程
+
+```
+用户正常发送
+    ↓
+AI 开始流式输出（streaming = true）
+    ↓
+用户输入新内容，点击发送（可重复多次）
+    ↓
+┌─────────────────────────────────────┐
+│ 输入框上方出现橙色等待块：           │
+│ ⏳ 排队 3 条: 第一条内容预览...      │
+│ 右侧有 × 可清空全部队列             │
+└─────────────────────────────────────┘
+    ↓
+每次有内容按发送 → 追加到队列（不打断AI）
+    ↓
+输入框清空后按发送 → 停止当前AI
+    ↓
+  ┌──── AI 输出结束（自然完成或被停止）────┐
+  │                                         │
+  ↓                                         │
+队列第一条自动发送 → AI 响应               │
+    ↓                                       │
+AI 输出完成 → 队列下一条自动发送...        │
+    ↓                                       │
+直到队列清空                               │
+└──────────────────────────────────────────┘
+```
+
+**撤回路径：**
+- 点击等待块右侧 × → 清空整个队列，不发送任何排队消息
+
+## 发送按钮状态
+
+| 状态 | 颜色 | 图标 | 行为 |
+|------|------|------|------|
+| 正常可发送 | 蓝色 `ACCENT` | ↑ 箭头 | 直接发送 |
+| 有内容 + AI输出中 | 橙色 `#FFAA33` | ↑ 箭头 | 按下=追加排队 |
+| 有队列 + 输入框空 + AI输出中 | 深橙 `#FF8800` | ■ 停止 | 按下=停止AI |
+| 无内容无队列 + AI输出中 | 红色 `DANGER` | ■ 停止 | 按下=停止AI |
+
+**关键区别：** 有内容时永远是"追加排队"而非"停止AI"，只有输入框为空时按下才会停止AI。
+
+## 代码实现
+
+文件：`ComposerView.java`
+
+### 1. 核心数据结构
+
+```java
+private LinearLayout pendingBlock;      // 橙色等待UI块
+private TextView pendingPreview;        // 等待块内的预览文字
+private final List<QueuedItem> pendingQueue = new ArrayList<>(); // 多条排队队列
+private boolean wasStreaming = false;
+
+// 队列项：每条排队消息包含文本和附件
+private static final class QueuedItem {
+    final String text;
+    final List<InputAttachment> attachments;
+    QueuedItem(String text, List<InputAttachment> attachments) {
+        this.text = text;
+        this.attachments = attachments;
+    }
+}
+```
+
+### 2. 等待块 UI 构建
+
+```java
+// Pending message block (shown when message is queued during streaming)
+pendingBlock = new LinearLayout(context);
+pendingBlock.setOrientation(HORIZONTAL);
+pendingBlock.setGravity(Gravity.CENTER_VERTICAL);
+pendingBlock.setBackgroundColor(0xFF252536);
+LineTheme.padding(pendingBlock, LineTheme.MD, LineTheme.SM, LineTheme.SM, LineTheme.SM);
+pendingBlock.setVisibility(GONE); // 默认隐藏
+
+// 左侧橙色竖条
+android.view.View pendingIcon = new android.view.View(context);
+pendingIcon.setBackgroundColor(0xFFFFAA33);
+pendingBlock.addView(pendingIcon, new LinearLayout.LayoutParams(
+    LineTheme.dp(context, 3), LayoutParams.MATCH_PARENT));
+
+// 预览文字
+pendingPreview = LineTheme.text(context, "", LineTheme.FONT_XS, 0xFFFFAA33, Typeface.NORMAL);
+pendingPreview.setSingleLine(true);
+pendingPreview.setEllipsize(TextUtils.TruncateAt.END);
+LinearLayout.LayoutParams ptp = new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1f);
+ptp.leftMargin = LineTheme.dp(context, LineTheme.SM);
+pendingBlock.addView(pendingPreview, ptp);
+
+// 右侧关闭按钮（清空整个队列）
+IconButtonView pendingClose = new IconButtonView(context, IconButtonView.CLOSE);
+pendingClose.setIconColor(LineTheme.TEXT_TERTIARY);
+pendingClose.setIconSizeDp(24, 14);
+pendingClose.setOnClickListener(v -> clearPending());
+pendingBlock.addView(pendingClose, new LinearLayout.LayoutParams(
+    LineTheme.dp(context, 24), LineTheme.dp(context, 24)));
+
+panel.addView(pendingBlock, new LinearLayout.LayoutParams(
+    LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+```
+
+### 3. 发送按钮点击逻辑
+
+```java
+sendButton.setOnClickListener(v -> {
+    if (streaming) {
+        if (canSend()) {
+            // 输入框有内容：追加排队（不打断AI）
+            queueCurrentInput();
+        } else {
+            // 输入框为空：停止AI（render()检测到停止后自动发送队列）
+            if (listener != null) listener.onStop();
+        }
+        return;
+    }
+    submitCurrentInput(); // 非streaming：正常发送
+});
+```
+
+### 4. render() 自动发送检测
+
+```java
+public void render(ChatUiState state) {
+    boolean wasStreamingBefore = streaming;
+    streaming = state.isStreaming();
+    // ... 其他UI更新 ...
+
+    // 关键：检测 streaming 从 true → false，且队列非空
+    if (wasStreamingBefore && !streaming && !pendingQueue.isEmpty()) {
+        post(() -> sendPending()); // 下一帧发送队列第一条
+    }
+
+    input.setEnabled(true); // 输入框永不禁用
+    updateSendButton();
+}
+```
+
+### 5. 排队入列（追加到队列尾部）
+
+```java
+private void queueCurrentInput() {
+    String text = input.getText().toString();
+    // 处理引用
+    if (quoteText != null && quoteText.length() > 0) {
+        String quoted = "> " + quoteText.replace("\n", "\n> ") + "\n\n";
+        text = quoted + text;
+        clearQuote();
+    }
+    pendingQueue.add(new QueuedItem(text, new ArrayList<>(attachments)));
+    input.setText("");
+    clearAttachments();
+    updatePendingBlock();
+    updateSendButton();
+}
+```
+
+### 6. 更新等待块显示（支持多条计数）
+
+```java
+private void updatePendingBlock() {
+    if (pendingQueue.isEmpty()) {
+        pendingBlock.setVisibility(GONE);
+        return;
+    }
+    int count = pendingQueue.size();
+    String first = pendingQueue.get(0).text;
+    String preview;
+    if (count == 1) {
+        preview = "⏳ 等待发送: " + (first.length() > 35 ? first.substring(0, 35) + "..." : first);
+    } else {
+        preview = "⏳ 排队 " + count + " 条: " + (first.length() > 30 ? first.substring(0, 30) + "..." : first);
+    }
+    pendingPreview.setText(preview);
+    pendingBlock.setVisibility(VISIBLE);
+}
+```
+
+### 7. 发送队列第一条
+
+```java
+private void sendPending() {
+    if (pendingQueue.isEmpty()) return;
+    QueuedItem item = pendingQueue.remove(0); // 取出第一条
+    updatePendingBlock(); // 更新显示（剩余条数）
+    if (listener != null) {
+        listener.onSend(item.text, item.attachments != null ? item.attachments : Collections.emptyList());
+    }
+}
+```
+
+### 8. 清空整个队列（撤回）
+
+```java
+private void clearPending() {
+    pendingQueue.clear();
+    pendingBlock.setVisibility(GONE);
+    updateSendButton();
+}
+```
+
+### 9. 按钮状态更新
+
+```java
+private void updateSendButton() {
+    boolean hasContent = canSend();
+    if (streaming) {
+        if (!pendingQueue.isEmpty() && !hasContent) {
+            // 有队列 + 输入框空：深橙停止按钮（按=停止AI并触发发送）
+            sendButton.setIconType(IconButtonView.STOP);
+            sendButton.setIconColor(LineTheme.TEXT_ON_COLOR);
+            sendButton.setIconSizeDp(40, 18);
+            sendButton.setBackground(LineTheme.rounded(getContext(), 0xFFFF8800, 20));
+        } else if (hasContent) {
+            // 有内容：橙色箭头（按=追加排队）
+            sendButton.setIconType(IconButtonView.ARROW_UP);
+            sendButton.setIconColor(LineTheme.TEXT_ON_COLOR);
+            sendButton.setIconSizeDp(40, 22);
+            sendButton.setBackground(LineTheme.rounded(getContext(), 0xFFFFAA33, 20));
+        } else {
+            // 无内容无队列：红色停止
+            sendButton.setIconType(IconButtonView.STOP);
+            sendButton.setIconColor(LineTheme.TEXT_ON_COLOR);
+            sendButton.setIconSizeDp(40, 18);
+            sendButton.setBackground(LineTheme.rounded(getContext(), LineTheme.DANGER, 20));
+        }
+    } else {
+        // 非streaming：正常蓝色发送
+        sendButton.setIconType(IconButtonView.ARROW_UP);
+        sendButton.setIconColor(hasContent ? LineTheme.TEXT_ON_COLOR : LineTheme.TEXT_TERTIARY);
+        sendButton.setIconSizeDp(40, 22);
+        sendButton.setBackground(LineTheme.rounded(getContext(),
+            hasContent ? LineTheme.ACCENT : LineTheme.SURFACE_LIGHT, 20));
+    }
+    sendButton.setEnabled(streaming || hasContent);
+    sendButton.setAlpha(sendButton.isEnabled() ? 1f : 0.72f);
+}
+```
+
+### 10. Enter 键也支持排队
+
+```java
+private boolean submitCurrentInput() {
+    if (!canSend()) return true;
+    if (streaming) {
+        // Enter键在streaming时：追加排队
+        queueCurrentInput();
+        return true;
+    }
+    // 正常发送流程...
+    String text = input.getText().toString();
+    if (listener != null) listener.onSend(text, getAttachments());
+    input.setText("");
+    clearAttachments();
+    return true;
+}
+```

--- a/docs/02_多选分享.md
+++ b/docs/02_多选分享.md
@@ -1,0 +1,717 @@
+# 二、消息操作栏 + 多选分享 + 引用 + 选中文字
+
+## 设计思想
+
+每条消息底部都有一排操作按钮，让用户**不离开聊天页面**就能完成所有消息相关操作。设计原则：
+
+- **扁平化入口**：复制/引用/分享/选中/多选/撤回，一排按钮全部可见，不藏在长按菜单里
+- **OPPO 兼容**：因 OPPO 系统长按/textIsSelectable 有 bug，所有功能改为按钮触发
+- **格式丰富**：分享支持 5 种格式（截图/PDF/MD/纯文本/剪贴板）
+- **QQ/微信兼容**：通过自定义 ContentProvider + query() + ClipData 实现
+
+## 消息操作栏按钮
+
+| 序号 | 图标 | 功能 | 说明 |
+|------|------|------|------|
+| 1 | COPY | 复制 | 复制消息全文到剪贴板 |
+| 2 | QUOTE | 引用 | 引用消息到输入框（带引用块UI） |
+| 3 | EXTERNAL_LINK | 分享 | 弹出格式选择（截图/PDF/MD/纯文本） |
+| 4 | FILE_PEN_LINE | 选中文字 | 弹出 EditText Dialog，可拖选复制 |
+| 5 | CIRCLE_CHECK | 多选导出 | 进入多选模式，勾选多条 → 合并导出 |
+| 6 | ROTATE_CCW | 撤回 | 仅用户消息显示 |
+
+---
+
+## 一、引用功能
+
+### 交互流程
+
+```
+点击引用按钮
+    ↓
+输入框上方出现引用预览块：
+┌─────────────────────────────────┐
+│ ▎ 被引用消息的前80字...    ×    │
+└─────────────────────────────────┘
+    ↓
+用户输入新内容，点击发送
+    ↓
+发送内容 = "> 引用原文\n\n" + 用户新消息
+    ↓
+引用块消失，正常发送
+```
+
+### 代码实现
+
+**触发入口（MainChatView）：**
+```java
+@Override
+public void onQuoteMessage(ChatMessage message) {
+    if (message != null && message.getContent() != null) {
+        composerView.setQuoteText(message.getContent());
+    }
+}
+```
+
+**引用块 UI（ComposerView）：**
+```java
+// 引用块构建
+quoteBlock = new LinearLayout(context);
+quoteBlock.setOrientation(HORIZONTAL);
+quoteBlock.setBackgroundColor(0xFF1E1E2E);
+quoteBlock.setVisibility(GONE); // 默认隐藏
+
+// 左侧蓝色竖条
+View quoteBar = new View(context);
+quoteBar.setBackgroundColor(LineTheme.ACCENT);
+quoteBlock.addView(quoteBar, new LayoutParams(dp(3), MATCH_PARENT));
+
+// 引用预览文字（单行省略）
+TextView quotePreview = LineTheme.text(context, "", FONT_XS, TEXT_SECONDARY, ITALIC);
+quotePreview.setSingleLine(true);
+quotePreview.setEllipsize(TextUtils.TruncateAt.END);
+
+// 关闭按钮
+IconButtonView quoteClose = new IconButtonView(context, IconButtonView.CLOSE);
+quoteClose.setOnClickListener(v -> clearQuote());
+```
+
+**设置引用文本：**
+```java
+public void setQuoteText(String text) {
+    quoteText = text;
+    if (text != null && text.length() > 0) {
+        TextView preview = (TextView) quoteBlock.getChildAt(1);
+        preview.setText(text.length() > 80 ? text.substring(0, 80) + "..." : text);
+        quoteBlock.setVisibility(VISIBLE);
+        input.requestFocus();
+    } else {
+        quoteBlock.setVisibility(GONE);
+    }
+}
+```
+
+**发送时拼接引用：**
+```java
+private boolean submitCurrentInput() {
+    String text = input.getText().toString();
+    // 引用存在时，拼接到前面
+    if (quoteText != null && quoteText.length() > 0) {
+        String quoted = "> " + quoteText.replace("\n", "\n> ") + "\n\n";
+        text = quoted + text;
+        clearQuote();
+    }
+    // ... 正常发送
+}
+```
+
+---
+
+## 二、选中文字
+
+### 避坑记录
+
+**OPPO 系统的坑：**
+- `setTextIsSelectable(true)` 会抢走同 item 内所有按钮的触摸事件
+- `Selection.setSelection()` 在 OPPO 上无视觉反馈
+- `performLongClick()` 无法触发系统选中菜单
+- **最终方案**：弹出 EditText Dialog（100% 兼容所有设备）
+
+### 交互流程
+
+```
+点击"选中文字"按钮
+    ↓
+弹出深色 Dialog，内含 EditText：
+┌──────────────────────────┐
+│ 长按选中文字              │
+│ ┌──────────────────────┐ │
+│ │ [全选高亮的消息内容]  │ │
+│ │ 可拖动选区手柄       │ │
+│ │ 长按弹出复制菜单     │ │
+│ └──────────────────────┘ │
+│              [关闭]      │
+└──────────────────────────┘
+```
+
+### 代码实现
+
+```java
+private void triggerTextSelection(View messageView, String content) {
+    Context ctx = getContext();
+    EditText et = new EditText(ctx);
+    et.setText(content);
+    et.setTextSize(15);
+    et.setTextColor(0xFFFFFFFF);
+    et.setBackgroundColor(0xFF1E1E2E);
+    et.setPadding(30, 30, 30, 30);
+    et.setFocusable(true);
+    et.setFocusableInTouchMode(true);
+    et.setKeyListener(null); // 只读但可选
+    et.setTextIsSelectable(true); // Dialog 内不会抢触摸
+    et.selectAll(); // 默认全选
+    
+    ScrollView sv = new ScrollView(ctx);
+    sv.addView(et);
+    new AlertDialog.Builder(ctx)
+            .setTitle("长按选中文字")
+            .setView(sv)
+            .setPositiveButton("关闭", null)
+            .show();
+}
+```
+
+**为什么 Dialog 内可以用 textIsSelectable：**
+Dialog 有自己独立的 Window，不存在同一 item 内按钮被抢的问题。
+
+---
+
+## 三、多选导出
+
+### 交互流程
+
+```
+点击消息底部 ✅ 多选按钮
+    ↓
+弹出多选对话框（列出所有消息，带 CheckBox）
+    ↓
+勾选需要的消息 → 点"合并转发"
+    ↓
+弹出格式选择：
+  ├── 对话截图(图片) → 生成聊天气泡长图 PNG
+  ├── PDF 文件 → A4 分页 PDF
+  ├── Markdown 文件(.md) → .md 文件分享
+  ├── 纯文本分享 → 系统 ACTION_SEND
+  └── 复制到剪贴板 → 直接复制（超5000字警告）
+```
+
+### 多选对话框代码
+
+```java
+private void showMultiSelectDialog(int triggerPosition) {
+    List<ChatMessage> messages = messageListView.getMessages();
+    if (messages == null || messages.isEmpty()) return;
+    
+    boolean[] checked = new boolean[messages.size()];
+    if (triggerPosition >= 0 && triggerPosition < checked.length) {
+        checked[triggerPosition] = true; // 预选触发消息
+    }
+    
+    String[] items = new String[messages.size()];
+    for (int i = 0; i < messages.size(); i++) {
+        ChatMessage msg = messages.get(i);
+        String role = msg.getRole() == ChatMessage.Role.USER ? "我" : "AI";
+        String preview = msg.getContent() == null ? "" : msg.getContent();
+        if (preview.length() > 50) preview = preview.substring(0, 50) + "...";
+        items[i] = "[" + role + "] " + preview;
+    }
+    
+    new AlertDialog.Builder(context)
+            .setTitle("选择消息合并转发")
+            .setMultiChoiceItems(items, checked, (d, which, isChecked) -> checked[which] = isChecked)
+            .setPositiveButton("合并转发", (d, w) -> {
+                List<ChatMessage> selected = new ArrayList<>();
+                for (int i = 0; i < checked.length; i++) {
+                    if (checked[i]) selected.add(messages.get(i));
+                }
+                if (selected.isEmpty()) {
+                    Toast.makeText(context, "未选择任何消息", Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                showMergeFormatDialog(selected);
+            })
+            .setNegativeButton("取消", null)
+            .show();
+}
+```
+
+### 格式选择对话框
+
+```java
+private void showMergeFormatDialog(List<ChatMessage> selected) {
+    String[] formats = {"对话截图(图片)", "PDF 文件", "Markdown 文件(.md)", "纯文本分享", "复制到剪贴板"};
+    new AlertDialog.Builder(getContext())
+            .setTitle("导出格式")
+            .setItems(formats, (dialog, which) -> {
+                if (which == 0) {
+                    shareAsChatImage(selected);  // 生成聊天截图
+                } else if (which == 1) {
+                    shareAsPdf(selected);        // PDF
+                } else if (which == 2) {
+                    shareAsFile(text, "chat_export.md", "application/octet-stream"); // MD文件
+                } else if (which == 3) {
+                    // 纯文本 ACTION_SEND
+                } else if (which == 4) {
+                    // 剪贴板（超5000字提示警告）
+                }
+            })
+            .show();
+}
+```
+
+---
+
+## 四、对话截图（聊天气泡长图）
+
+### 设计规格
+
+- 宽度：720px
+- 背景：深色 `#1A1A2E`
+- 用户消息：靠右，蓝色气泡 `#3B5998`
+- AI 消息：靠左，深灰气泡 `#2D2D44`
+- 圆角：24px
+- 文字：28px 浅灰色 `#E8E8E8`
+- 名称：22px 灰色 `#999999`
+- 页脚：居中 "—— 来自 LineCode Pro"
+- 自动换行、自动长图（高度按内容计算）
+
+### 代码实现
+
+```java
+private void shareAsChatImage(List<ChatMessage> messages) {
+    int imgWidth = 720;
+    int padding = 32;
+    int bubbleMaxWidth = imgWidth - padding * 2 - 60;
+    int fontSize = 28;
+    int bubbleRadius = 24;
+
+    Paint textPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    textPaint.setTextSize(fontSize);
+
+    // 第一遍：计算总高度（自动换行）
+    int totalHeight = padding;
+    List<String[]> wrappedMessages = new ArrayList<>();
+    for (ChatMessage msg : messages) {
+        String[] lines = wrapText(msg.getContent(), textPaint, bubbleMaxWidth - 48);
+        wrappedMessages.add(lines);
+        totalHeight += 22 + 8 + 36 + lines.length * (fontSize + 6) + 20;
+    }
+    totalHeight += 80; // footer + bottom padding
+
+    // 创建 Bitmap
+    Bitmap bitmap = Bitmap.createBitmap(imgWidth, totalHeight, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(bitmap);
+    canvas.drawColor(0xFF1A1A2E);
+
+    // 第二遍：绘制每条消息
+    int y = padding;
+    for (int i = 0; i < messages.size(); i++) {
+        boolean isUser = messages.get(i).getRole() == ChatMessage.Role.USER;
+        String[] lines = wrappedMessages.get(i);
+        
+        // 计算气泡宽高
+        int bubbleWidth = /* 最宽行 + padding */;
+        int bubbleHeight = /* 行数 * 行高 + padding */;
+        int bubbleLeft = isUser ? (imgWidth - padding - bubbleWidth) : padding;
+
+        // 画名字（用户靠右，AI靠左）
+        canvas.drawText(isUser ? "我" : "AI", ...);
+        
+        // 画圆角气泡
+        bubblePaint.setColor(isUser ? 0xFF3B5998 : 0xFF2D2D44);
+        canvas.drawRoundRect(rect, bubbleRadius, bubbleRadius, bubblePaint);
+        
+        // 画文字内容
+        for (String line : lines) {
+            canvas.drawText(line, bubbleLeft + 24, textY, textPaint);
+            textY += fontSize + 6;
+        }
+    }
+
+    // 画 footer
+    canvas.drawText("—— 来自 LineCode Pro", centerX, y, footerPaint);
+
+    // 保存为 PNG 并通过 ShareFileProvider 分享
+    File imgFile = new File(cacheDir, "chat_screenshot.png");
+    bitmap.compress(Bitmap.CompressFormat.PNG, 100, new FileOutputStream(imgFile));
+    // 分享...
+}
+```
+
+### 文字换行工具方法
+
+```java
+private String[] wrapText(String text, Paint paint, int maxWidth) {
+    List<String> result = new ArrayList<>();
+    String[] paragraphs = text.split("\n");
+    for (String para : paragraphs) {
+        if (para.isEmpty()) { result.add(""); continue; }
+        int start = 0;
+        while (start < para.length()) {
+            int end = para.length();
+            while (paint.measureText(para, start, end) > maxWidth && end > start + 1) {
+                end--;
+            }
+            result.add(para.substring(start, end));
+            start = end;
+        }
+    }
+    return result.toArray(new String[0]);
+}
+```
+
+---
+
+## 五、PDF 导出
+
+### 规格
+
+- A4 纸张（595×842pt）
+- 边距 40pt
+- 标题 14pt 加粗，正文 11pt
+- 自动分页换行
+- 页脚 "—— 来自 LineCode Pro"
+
+### 代码实现
+
+```java
+private void shareAsPdf(List<ChatMessage> messages) {
+    PdfDocument doc = new PdfDocument();
+    int pageWidth = 595, pageHeight = 842, margin = 40;
+    int y = margin, pageNum = 1;
+    PageInfo pageInfo = new PageInfo.Builder(pageWidth, pageHeight, pageNum).create();
+    Page page = doc.startPage(pageInfo);
+    Canvas canvas = page.getCanvas();
+
+    for (ChatMessage msg : messages) {
+        String role = msg.getRole() == ChatMessage.Role.USER ? "我" : "AI";
+        // 画标题
+        canvas.drawText(role, margin, y + 14, titlePaint);
+        y += 22;
+        // 画内容（自动换行+分页）
+        for (String line : content.split("\n")) {
+            int maxChars = (pageWidth - margin * 2) / 6;
+            while (line.length() > 0) {
+                String seg = line.substring(0, Math.min(maxChars, line.length()));
+                line = line.substring(seg.length());
+                if (y + 15 > pageHeight - margin) {
+                    doc.finishPage(page); pageNum++;
+                    // 新建页...
+                }
+                canvas.drawText(seg, margin, y + 11, textPaint);
+                y += 14;
+            }
+        }
+    }
+    // 写文件 → shareAsFile(null, "chat_export.pdf", "application/pdf")
+}
+```
+
+---
+
+## 六、Markdown 文件分享
+
+### 生成格式
+
+```markdown
+## 我
+
+用户消息内容...
+
+---
+
+## AI
+
+AI回复内容...
+
+---
+
+—— 来自 LineCode Pro
+```
+
+### 写文件 + 分享
+
+```java
+shareAsFile(text, "chat_export.md", "application/octet-stream");
+```
+
+---
+
+## 七、ShareFileProvider（QQ/微信兼容的关键）
+
+### 避坑记录
+
+| 问题 | 原因 | 解决 |
+|------|------|------|
+| QQ 报"文件不存在" | QQ 调用 query() 检查文件，返回 null 就认为不存在 | 实现 query() 返回 MatrixCursor |
+| QQ 不识别 text/markdown | QQ 没注册为 markdown handler | MIME 改为 application/octet-stream |
+| 权限不传递 | 部分 APP 只从 ClipData 读权限 | setClipData() 额外设置 |
+| FileProvider 不存在 | 项目不用 AndroidX | 自写 ContentProvider |
+
+### 完整代码
+
+```java
+public final class ShareFileProvider extends ContentProvider {
+
+    // 生成 content:// URI
+    public static Uri uriFor(Context context, File file) {
+        return new Uri.Builder()
+                .scheme("content")
+                .authority(context.getPackageName() + ".fileprovider")
+                .appendPath(file.getName())
+                .build();
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        String name = uri.getLastPathSegment();
+        if (name != null && name.endsWith(".md")) return "application/octet-stream";
+        if (name != null && name.endsWith(".pdf")) return "application/pdf";
+        if (name != null && name.endsWith(".png")) return "image/png";
+        if (name != null && name.endsWith(".txt")) return "text/plain";
+        return "application/octet-stream";
+    }
+
+    // QQ 兼容关键：返回文件名和大小
+    @Override
+    public Cursor query(Uri uri, String[] projection, ...) {
+        File file = resolveFile(uri);
+        if (!file.isFile()) return null;
+        String[] cols = projection != null ? projection
+                : new String[]{OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
+        MatrixCursor cursor = new MatrixCursor(cols, 1);
+        Object[] row = new Object[cols.length];
+        for (int i = 0; i < cols.length; i++) {
+            if (OpenableColumns.DISPLAY_NAME.equals(cols[i])) row[i] = file.getName();
+            else if (OpenableColumns.SIZE.equals(cols[i])) row[i] = file.length();
+            else row[i] = null;
+        }
+        cursor.addRow(row);
+        return cursor;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        // 验证路径安全性（防止路径遍历攻击）
+        File dir = new File(getContext().getCacheDir(), "share");
+        File file = new File(dir, uri.getLastPathSegment());
+        if (!file.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+            throw new FileNotFoundException("Invalid path");
+        }
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+}
+```
+
+### shareAsFile 通用方法
+
+```java
+private void shareAsFile(String content, String fileName, String mimeType) {
+    File shareDir = new File(getCacheDir(), "share");
+    shareDir.mkdirs();
+    File file = new File(shareDir, fileName);
+    if (content != null) {
+        new FileOutputStream(file).write(content.getBytes("UTF-8"));
+    }
+    if (!file.isFile() || file.length() == 0) {
+        Toast "文件生成失败"; return;
+    }
+    Uri uri = ShareFileProvider.uriFor(getContext(), file);
+    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+    shareIntent.setType(mimeType);
+    shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+    shareIntent.setClipData(ClipData.newRawUri("", uri)); // QQ 兼容关键
+    shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    startActivity(Intent.createChooser(shareIntent, "分享文件"));
+}
+```
+
+### AndroidManifest 注册
+
+```xml
+<provider
+    android:name=".log.ShareFileProvider"
+    android:authorities="${applicationId}.fileprovider"
+    android:exported="false"
+    android:grantUriPermissions="true" />
+```
+
+---
+
+## 八、消息操作栏组件
+
+### MessageActionBarView.java
+
+```java
+public final class MessageActionBarView extends LinearLayout {
+    // 6个按钮
+    private final IconButtonView copyButton;    // COPY
+    private final IconButtonView quoteButton;   // QUOTE
+    private final IconButtonView shareButton;   // EXTERNAL_LINK
+    private final IconButtonView selectButton;  // FILE_PEN_LINE
+    private final IconButtonView multiSelectButton; // CIRCLE_CHECK
+    private final IconButtonView recallButton;  // ROTATE_CCW (仅用户消息)
+
+    public interface Listener {
+        void onCopy();
+        void onQuote();
+        void onShare();
+        void onSelect();
+        void onMultiSelect();
+        void onRecall();
+    }
+}
+```
+
+### MessageActionListener.java（View → Coordinator 回调）
+
+```java
+public interface MessageActionListener {
+    void onCopyMessage(ChatMessage message);
+    void onRecallMessage(ChatMessage message);
+    void onQuoteMessage(ChatMessage message);
+    void onShareMessage(ChatMessage message);
+    void onSelectMessage(ChatMessage message, View messageView);
+    void onMultiSelectMessage(ChatMessage message);
+}
+```
+
+---
+
+## 九、文件名自定义 + AI 智能取名
+
+### 设计思想
+
+分享成 PDF / Markdown 文件时，如果文件名是固定的 `chat_export.pdf`，多次分享会互相覆盖、且传给朋友时无法辨识内容。因此在真正写文件前，弹出一个**苹果风格圆角卡片**让用户命名，并提供「✨ AI 取名」一键根据内容生成有意义的文件名。
+
+设计原则：
+
+- **可选不强制**：默认名 `chat_export`，用户不改也能直接确定
+- **一键智能**：点「✨ AI 取名」自动从内容里提炼标题
+- **仿苹果视觉**：圆角卡片 18dp、输入框圆角描边 12dp、AI 按钮胶囊 14dp
+- **文件名安全**：自动清理 `/ \ : * ? " < > |` 等非法字符
+
+### 交互流程
+
+```
+多选导出 → 选择 PDF / Markdown
+    ↓
+弹出圆角卡片：
+┌───────────────────────────┐
+│  文件名称                  │
+│  后缀自动添加: .pdf        │
+│ ┌───────────────────────┐ │
+│ │ chat_export           │ │  ← 圆角输入框（默认全选）
+│ └───────────────────────┘ │
+│  [ ✨ AI 取名 ]            │  ← 紫色胶囊按钮
+│         [取消]  [确定]     │
+└───────────────────────────┘
+    ↓
+点「✨ AI 取名」→ 从内容首行提炼标题填入
+点「确定」→ 清理非法字符 → 写文件分享
+```
+
+### 触发入口
+
+导出格式选择后，PDF / MD 都先走命名对话框（而非直接写死文件名）：
+
+```java
+} else if (which == 1) {
+    askFileNameAndShare("chat_export", ".pdf", selected, text, true);
+} else if (which == 2) {
+    askFileNameAndShare("chat_export", ".md", selected, text, false);
+}
+```
+
+单条消息分享同理，默认名带角色：
+
+```java
+askFileNameAndShare("message_" + role, ".pdf", single, mdText, true);
+askFileNameAndShare("message_" + role, ".md", null, text, false);
+```
+
+### 命名对话框（苹果圆角卡片）
+
+```java
+private void askFileNameAndShare(String defaultName, String ext,
+        List<ChatMessage> messages, String mdText, boolean isPdf) {
+    Context ctx = getContext();
+
+    // 圆角卡片容器（18dp 圆角）
+    LinearLayout card = new LinearLayout(ctx);
+    card.setOrientation(LinearLayout.VERTICAL);
+    card.setBackground(LineTheme.rounded(ctx, 0xFF2A2A3E, 18));
+
+    // 提示：后缀自动添加
+    TextView hint = LineTheme.text(ctx, "后缀自动添加: " + ext,
+            LineTheme.FONT_XS, 0xFF999999, Typeface.NORMAL);
+    card.addView(hint, ...);
+
+    // 圆角描边输入框（默认全选便于覆写）
+    EditText input = new EditText(ctx);
+    input.setText(defaultName);
+    input.setSelectAllOnFocus(true);
+    input.setSingleLine(true);
+    input.setBackground(LineTheme.roundedStroke(ctx, 0xFF1E1E30, 12, 0xFF444466));
+    card.addView(input, ...);
+
+    // ✨ AI 取名 胶囊按钮（紫色 14dp 圆角）
+    TextView aiBtn = new TextView(ctx);
+    aiBtn.setText("✨ AI 取名");
+    aiBtn.setBackground(LineTheme.rounded(ctx, 0xFF5B4FCF, 14));
+    aiBtn.setOnClickListener(v -> {
+        aiBtn.setText("✨ 思考中...");
+        aiBtn.setEnabled(false);
+        String summary = generateSmartFileName(mdText); // 从内容提炼
+        input.setText(summary);
+        input.selectAll();
+        aiBtn.setText("✨ AI 取名");
+        aiBtn.setEnabled(true);
+    });
+    card.addView(aiBtn, ...);
+
+    new AlertDialog.Builder(ctx)
+            .setTitle("文件名称")
+            .setView(card)
+            .setPositiveButton("确定", (d, w) -> {
+                String name = input.getText().toString().trim();
+                if (name.isEmpty()) name = defaultName;
+                // 清理非法文件名字符
+                name = name.replaceAll("[/\\\\:*?\"<>|]", "_");
+                if (isPdf) shareAsPdfWithName(messages, name + ext);
+                else shareAsFile(mdText, name + ext, "application/octet-stream");
+            })
+            .setNegativeButton("取消", null)
+            .show();
+}
+```
+
+### AI 智能取名逻辑
+
+从对话内容里跳过 Markdown 符号，取第一段有意义的文字（≥4 字）作为文件名，截断到 20 字：
+
+```java
+private String generateSmartFileName(String content) {
+    if (content == null || content.isEmpty()) return "chat";
+    String[] lines = content.split("\n");
+    for (String line : lines) {
+        // 去掉行首的 # > - * 和空白
+        String clean = line.replaceAll("^[#>\\-*\\s]+", "").trim();
+        if (clean.length() >= 4) {
+            if (clean.length() > 20) clean = clean.substring(0, 20);
+            return clean.replaceAll("[/\\\\:*?\"<>|]", "_");
+        }
+    }
+    return "chat_" + System.currentTimeMillis() % 10000;
+}
+```
+
+### 避坑记录
+
+| 问题 | 原因 | 解决 |
+|------|------|------|
+| 文件互相覆盖 | 固定文件名 chat_export | 分享前弹命名框 |
+| 传给朋友认不出内容 | 文件名无意义 | AI 取名从内容提炼标题 |
+| 文件名带 `/ : *` 导致写入失败 | 非法字符 | `replaceAll` 统一替换为 `_` |
+| 输入框要手动全选删除 | 默认光标在末尾 | `setSelectAllOnFocus(true)` |
+
+---
+
+## 十、来源标识规范
+
+所有分享内容末尾统一附带：
+
+- Markdown: `*—— 来自 LineCode Pro*`
+- 纯文本: `—— 来自 LineCode Pro`
+- PDF: 灰色小字页脚
+- 截图: 底部居中灰色文字


### PR DESCRIPTION
## 说明

本 PR 新增两篇功能说明文档（**纯文档，不改动任何代码**），对 v1.1.8 的两组交互功能做实现说明，方便后续贡献者理解与对接。

### docs/01_发送队列.md
- 发送队列交互机制：AI 生成期间再次点击发送时，输入框**有内容则追加排队**、**为空则停止**当前生成
- 多条排队消息逐条堆叠展示（可折叠、单条删除）
- 队列在本轮生成结束后自动出队发送

### docs/02_多选分享.md
- 消息操作栏（复制 / 引用 / 选中 / 分享 / 多选 / 撤回）
- 引用功能、选中文字（OPPO 兼容的 EditText Dialog 方案）
- 多选导出：对话截图（Canvas 气泡长图）、PDF（A4 分页）、Markdown、纯文本
- ShareFileProvider：QQ / 微信兼容避坑（query 返回文件信息、ClipData 权限、MIME 类型）
- 文件名自定义 + AI 智能取名

> 文档均为通用实现说明，不含任何服务器地址、密钥等敏感信息。

## Summary by Sourcery

Add documentation describing the sending queue interaction and multi-select sharing features for version v1.1.8.

Documentation:
- Add a new doc outlining the behavior and UX of the message sending queue feature.
- Add a new doc explaining the multi-select sharing workflow, export formats, and related client integration details.